### PR TITLE
Minor improvement to the TCP library

### DIFF
--- a/src/chord/ChordNode.h
+++ b/src/chord/ChordNode.h
@@ -145,7 +145,7 @@ class ChordNode
 
     ThreadPool m_threadPool;
 
-    TcpServer m_tcpServer;
+    tcp::TcpServer m_tcpServer;
 
     struct NodeConnection
     {

--- a/src/tcp/TcpAcceptor.cpp
+++ b/src/tcp/TcpAcceptor.cpp
@@ -21,6 +21,18 @@ TcpClientAcceptor::TcpClientAcceptor(std::string ipAddress,
   inet_pton(AF_INET, ipAddress.c_str(), &m_address.sin_addr);
 }
 
+TcpClientAcceptor::TcpClientAcceptor(uint32_t ipAddress,
+                                     uint16_t portNumber,
+                                     TcpClientManager* clientManager)
+  : m_fd(socket(AF_INET, SOCK_STREAM, 0)),
+    m_clientManager(clientManager),
+    m_running(false)
+{
+  m_address.sin_family = AF_INET;
+  m_address.sin_port = htons(portNumber);
+  m_address.sin_addr.s_addr = htonl(ipAddress);
+}
+
 TcpClientAcceptor::~TcpClientAcceptor()
 {
   stop();

--- a/src/tcp/TcpAcceptor.h
+++ b/src/tcp/TcpAcceptor.h
@@ -2,8 +2,7 @@
 #define TCP_ACCEPTOR_H_
 
 #include <cstdint>
-#include <netinet/in.h>
-#include <string>
+#include <netinet/in.h> // sockaddr_in
 #include <thread>
 #include <atomic>
 

--- a/src/tcp/TcpAcceptor.h
+++ b/src/tcp/TcpAcceptor.h
@@ -13,6 +13,7 @@ class TcpClientAcceptor
 {
   public:
     TcpClientAcceptor(std::string ipAddress, uint16_t portNumber, TcpClientManager* clientManager);
+    TcpClientAcceptor(uint32_t ipAddress, uint16_t portNumber, TcpClientManager* clientManager);
     ~TcpClientAcceptor();   
 
     void start();

--- a/src/tcp/TcpClient.h
+++ b/src/tcp/TcpClient.h
@@ -38,6 +38,7 @@ class TcpClient : public TcpClient_I
   public:
     TcpClient() = default;
     TcpClient(const IpAddressString& ipAddress, const PortNumber& port);
+    TcpClient(const IpAddressV4& ipAddress, const PortNumber& port);
     ~TcpClient();
 
     void start() override;
@@ -54,7 +55,7 @@ class TcpClient : public TcpClient_I
     int m_fd;
     sockaddr_in m_socketAddress;
     socklen_t m_socketAddressLength;
-    
+
     onReceiveCallback m_onReceiveCallback;
     std::thread m_receiveThread;
     std::atomic<bool> m_running;

--- a/src/tcp/TcpServer.cpp
+++ b/src/tcp/TcpServer.cpp
@@ -60,7 +60,7 @@ void TcpServer::stop()
   }
 }
 
-void TcpServer::subscribeToAll(std::function<void(int, std::string)> callback)
+void TcpServer::subscribeToAll(OnReceiveCallback callback)
 {
   m_subscribers.push_back(callback);
 }
@@ -131,7 +131,9 @@ void TcpServer::threadFunction()
         {
           for (const auto& subscriber : m_subscribers)
           {
-            subscriber(client, std::string{messageBuffer, bytesIn});
+            auto* messageData = new uint8_t[bytesIn];
+            memcpy(messageData, messageBuffer, bytesIn);
+            subscriber(messageData, bytesIn);
           }
         }
       }

--- a/src/tcp/TcpServer.cpp
+++ b/src/tcp/TcpServer.cpp
@@ -1,13 +1,6 @@
 #include "TcpServer.h"
 #include <cstring>
 #include <iostream>
-#include <unistd.h>
-
-
-LittleTestTcpServer::LittleTestTcpServer(std::string ipAddress, uint16_t portNumber)
-  : m_tcpClientAcceptor{ipAddress, portNumber, nullptr}
-{
-}
 
 TcpServer::TcpServer(std::string ipAddress, uint16_t portNumber)
   : m_tcpClientAcceptor{ipAddress, portNumber, &m_tcpClientManager},

--- a/src/tcp/TcpServer.cpp
+++ b/src/tcp/TcpServer.cpp
@@ -2,6 +2,8 @@
 #include <cstring>
 #include <iostream>
 
+namespace tcp {
+
 TcpServer::TcpServer(std::string ipAddress, uint16_t portNumber)
   : m_tcpClientAcceptor{ipAddress, portNumber, &m_tcpClientManager},
     m_running(false)
@@ -145,4 +147,5 @@ void TcpServer::threadFunction()
 
 }
 
+} // namespace tcp
 

--- a/src/tcp/TcpServer.cpp
+++ b/src/tcp/TcpServer.cpp
@@ -15,6 +15,12 @@ TcpServer::TcpServer(std::string ipAddress, uint16_t portNumber)
 {
 }
 
+TcpServer::TcpServer(uint32_t ipAddress, uint16_t portNumber)
+  : m_tcpClientAcceptor{ipAddress, portNumber, &m_tcpClientManager},
+    m_running(false)
+{
+}
+
 TcpServer::~TcpServer()
 {
   std::cout << "TcpServer::~TcpServer started" << std::endl;

--- a/src/tcp/TcpServer.cpp
+++ b/src/tcp/TcpServer.cpp
@@ -18,42 +18,25 @@ TcpServer::TcpServer(uint32_t ipAddress, uint16_t portNumber)
 
 TcpServer::~TcpServer()
 {
-  std::cout << "TcpServer::~TcpServer started" << std::endl;
   stop();
 }
 
 void TcpServer::start()
 {
-  std::cout << "TcpServer::start started" << std::endl;
   try
   {
-  m_running = true;
+    m_running = true;
+    m_thread = std::thread(&TcpServer::threadFunction, this);
+    m_tcpClientAcceptor.start();
   }
   catch (const std::exception& e)
   {
-    std::cout << "TcpServer::start exception in setting m_running: " << e.what() << std::endl;
-  }
-  try
-  {
-  m_thread = std::thread(&TcpServer::threadFunction, this);
-  }
-  catch (const std::exception& e)
-  {
-    std::cout << "TcpServer::start exception in creating thread: " << e.what() << std::endl;
-  }
-  try
-  {
-  m_tcpClientAcceptor.start();
-  }
-  catch (const std::exception& e)
-  {
-    std::cout << "TcpServer::start exception: " << e.what() << std::endl;
+    std::cout << "TcpServer could not be started: " << e.what() << std::endl;
   }
 }
 
 void TcpServer::stop()
 {
-  std::cout << "TcpServer::stop started" << std::endl;
   if (m_running)
   {
     m_running = false;
@@ -94,7 +77,6 @@ void TcpServer::threadFunction()
 
   while (m_running)
   {
-    std::cout << "TcpServer::threadFunction running" << std::endl;
     FD_ZERO(&master);
 
     auto allClientFds = m_tcpClientManager.getAllClientFds();
@@ -125,8 +107,6 @@ void TcpServer::threadFunction()
 
         if (bytesIn <= 0)
         {
-          std::cout << "Closing connection to a disconnected client " << client << ", " << socketCount << std::endl;
-
           m_tcpClientManager.processClientDisconnecion(client);
         }
         else
@@ -143,7 +123,6 @@ void TcpServer::threadFunction()
     }
   }
 
-  std::cout << "Server Terminated by call to stop()" << std::endl;
 
 }
 

--- a/src/tcp/TcpServer.h
+++ b/src/tcp/TcpServer.h
@@ -13,7 +13,7 @@ using OnReceiveCallback = std::function<void(uint8_t*, std::size_t)>;
 class TcpServer_I 
 {
   public:
-    virtual ~TcpServer_I() {}
+    virtual ~TcpServer_I() = default;
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual void subscribeToAll(OnReceiveCallback callback) = 0;

--- a/src/tcp/TcpServer.h
+++ b/src/tcp/TcpServer.h
@@ -22,6 +22,7 @@ class TcpServer : public TcpServer_I
 {
   public:
     TcpServer(std::string ipAddress, uint16_t portNumber);
+    TcpServer(uint32_t ipAddress, uint16_t portNumber);
     ~TcpServer() override;
 
     void start() override;

--- a/src/tcp/TcpServer.h
+++ b/src/tcp/TcpServer.h
@@ -6,6 +6,8 @@
 #include <functional>
 #include <atomic>
 
+namespace tcp {
+
 using OnReceiveCallback = std::function<void(uint8_t*, std::size_t)>;
 
 class TcpServer_I 
@@ -43,6 +45,8 @@ class TcpServer : public TcpServer_I
     std::thread m_thread;
     std::atomic<bool> m_running;
 };
+
+} // namespace tcp
 
 #endif // TCP_SERVER_H_
 

--- a/src/tcp/TcpServer.h
+++ b/src/tcp/TcpServer.h
@@ -42,17 +42,5 @@ class TcpServer : public TcpServer_I
     std::atomic<bool> m_running;
 };
 
-class LittleTestTcpServer
-{
-  public:
-    LittleTestTcpServer(std::string ipAddress, uint16_t portNumber);
-
-  private:
-    TcpClientManager m_tcpClientManager;
-    TcpClientAcceptor m_tcpClientAcceptor;
-
-};
-
-
 #endif // TCP_SERVER_H_
 

--- a/src/tcp/TcpServer.h
+++ b/src/tcp/TcpServer.h
@@ -6,13 +6,15 @@
 #include <functional>
 #include <atomic>
 
+using OnReceiveCallback = std::function<void(uint8_t*, std::size_t)>;
+
 class TcpServer_I 
 {
   public:
     virtual ~TcpServer_I() {}
     virtual void start() = 0;
     virtual void stop() = 0;
-    virtual void subscribeToAll(std::function<void(int, std::string)> callback) = 0;
+    virtual void subscribeToAll(OnReceiveCallback callback) = 0;
     virtual void broadcast(const std::string& message) = 0;
     virtual void multicast(const std::string& message, std::vector<int> fds) = 0;
     virtual void unicast(const std::string& message, int fd) = 0;
@@ -28,7 +30,7 @@ class TcpServer : public TcpServer_I
     void start() override;
     void stop() override;
 
-    void subscribeToAll(std::function<void(int, std::string)> callback) override;
+    void subscribeToAll(OnReceiveCallback callback) override;
     void broadcast(const std::string& message) override;
     void multicast(const std::string& message, std::vector<int> fds) override;
     void unicast(const std::string& message, int fd) override;
@@ -37,7 +39,7 @@ class TcpServer : public TcpServer_I
     void threadFunction();
     TcpClientManager m_tcpClientManager;
     TcpClientAcceptor m_tcpClientAcceptor;
-    std::vector<std::function<void(int, std::string)>> m_subscribers;
+    std::vector<OnReceiveCallback> m_subscribers;
     std::thread m_thread;
     std::atomic<bool> m_running;
 };


### PR DESCRIPTION
This PR makes a few small improvements to the TCP library which are either required for further implementation of the chord algorithm, or are just nice to have:

* clean up some code: removes excessive try/catch blocks, print statements, header includes, and unused classes
* TcpServer is moved into the tcp namespace
* Server subscriptions use a callback that takes an array of uint8_t instead of std::string

